### PR TITLE
PlayerSay callback added to easily manage chat functionality from gsc

### DIFF
--- a/src/g_sv_cmds.c
+++ b/src/g_sv_cmds.c
@@ -602,13 +602,15 @@ __cdecl void G_Say(gentity_t *ent, gentity_t *target, int mode, const char *chat
         return;
     }
 
-    /*
-	Removed. Create a plugin if you want to capature chat.
+    
+	// Removed. Create a plugin if you want to capture chat.
+    // Addition: Readded the previously removed callback
+
 	if(Scr_PlayerSay(ent, mode, textptr))
 	{
 		return;
 	}
-*/
+
     if (text[0] != 0x15 && text[0] != 0x14 && !g_allowConsoleSay->boolean)
         return;
 
@@ -628,12 +630,15 @@ __cdecl void G_Say(gentity_t *ent, gentity_t *target, int mode, const char *chat
         Com_Printf(CON_CHANNEL_SERVER, "Say %s: %s\n", name, text);
     }
 
+    // Chat sending should be handled by the callback function
+    /*
     // send it to all the apropriate clients
     for (j = 0; j < level.maxclients; j++)
     {
         other = &g_entities[j];
         G_SayTo(ent, other, mode, color, teamname, name, text);
     }
+    */
 }
 
 #define MAX_REDIRECTDESTINATIONS 4

--- a/src/scr_vm_callbacks.c
+++ b/src/scr_vm_callbacks.c
@@ -27,7 +27,6 @@
 
 //Only CoD4 gamescript callback functions here
 
-/*
 
 qboolean Scr_PlayerSay(gentity_t* from, int mode, const char* text){
 
@@ -54,13 +53,20 @@ qboolean Scr_PlayerSay(gentity_t* from, int mode, const char* text){
     }
 
     if(mode == 0)
+	{
         Scr_AddBool( qfalse );
+	}
     else
+	{
         Scr_AddBool( qtrue );
+	}
 
-    Scr_AddString( textbuf );
+	Scr_AddString( textbuf );
 
-    threadId = Scr_ExecEntThread(from, callback, 2);
+	// Addition: Player sending the message is also captured in callback
+    Scr_AddEntity( from );
+	
+    threadId = Scr_ExecEntThread(from, callback, 3);
 
     Scr_FreeThread(threadId);
 
@@ -68,7 +74,6 @@ qboolean Scr_PlayerSay(gentity_t* from, int mode, const char* text){
 
 }
 
-*/
 
 qboolean Scr_ScriptCommand(int clientnum, const char* cmd, const char* args){
 

--- a/src/scr_vm_main.c
+++ b/src/scr_vm_main.c
@@ -750,6 +750,7 @@ void GScr_LoadGameTypeScript(void)
 
 	/**************** Additional *************************/
 	script_CallBacks_new[SCR_CB_SCRIPTCOMMAND] = GScr_LoadScriptAndLabel("maps/mp/gametypes/_callbacksetup", "CodeCallback_ScriptCommand", 0);
+	script_CallBacks_new[SCR_CB_SAY] = GScr_LoadScriptAndLabel("maps/mp/gametypes/_callbacksetup", "CodeCallback_PlayerSay", 1);
 }
 
 void __cdecl GScr_LoadScripts(void)


### PR DESCRIPTION
Inside maps\mp\gametypes\\_callbacksetup.gsc, following callback has to be added for chat to work
```c
/*================
Called by code when a player sends a message
mode = 0 for normal and 1 for teamchat
text = chat itself
player = player entity
================*/
CodeCallback_PlayerSay(player, text, mode)
{
	prefix = ":^7 ";
	
	if (mode == 1)
	{
		prefix = ":^5 ";
	}
	
	for (i = 0; i < level.players.size; i++)
	{
		sendGameServerCommand(level.players[i] getEntityNumber(), 1, "h \""+ player.name + prefix + text + "\"");
	}
}
//=============================================================================
```